### PR TITLE
Fix usage of delayed_reply

### DIFF
--- a/lib/alice/handlers/haha.ex
+++ b/lib/alice/handlers/haha.ex
@@ -106,5 +106,6 @@ defmodule Alice.Handlers.Haha do
     conn
     |> reply("https://i.imgur.com/KZ0rw68.gif")
     |> delayed_reply(sorted_winners(conn, &>/2), 1000)
+    conn
   end
 end


### PR DESCRIPTION
Fixes this error:
```elixir
** (FunctionClauseError) no function clause matching in Alice.Handlers.Help.match_routes/1
```

`delayed_reply/3` returns a task, so return the original conn passed into delayed reply.


Reference:
https://github.com/alice-bot/alice/blob/d90bd57696cc130f1894b075a64c779ebef2aeee/lib/alice/router/helpers.ex#L67-L88